### PR TITLE
allow user to link account to user with same name

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -775,7 +775,15 @@ class CoAuthors_Guest_Authors
 		if ( $user
 			&& is_user_member_of_blog( $user->ID, get_current_blog_id() )
 			&& $user->user_login != get_post_meta( $original_args['ID'], $this->get_post_meta_key( 'linked_account' ), true ) ) {
-			wp_die( esc_html__( 'Guest authors cannot be created with the same user_login value as a user. Try creating a profile from the user on the Manage Users listing instead.', 'co-authors-plus' ) );
+			// if user has selected to link account to matching user we don't have to bail
+			if ( $_POST['cap-linked_account'] > 0 && ( (int)$_POST['cap-linked_account'] === (int)$user->ID ) ) {
+				return $post_data;
+			}
+			// if user has selected to link account NOT matching user, bail with custom message
+			if ( $_POST['cap-linked_account'] > 0 && ( (int)$_POST['cap-linked_account'] !== (int)$user->ID ) ) {
+				wp_die( esc_html__( 'Please map the guest author to the user with the same username', 'co-authors-plus' ) );
+			}
+			wp_die( esc_html__( 'Guest authors cannot have the same user_login value as a user.', 'co-authors-plus' ) );
 		}
 
 		// Guest authors can't have the same post_name value


### PR DESCRIPTION
fixes https://github.com/Automattic/Co-Authors-Plus/issues/578

If co-author is created first then a worpress user can be created with the same username. If this happens currently, when the editor tries to update the co-author, a die message is thrown. This change encourages the editor to go back and link the co-author with the matching wordpress user.